### PR TITLE
Remove 'set -u' option from entrypoint

### DIFF
--- a/apache/entrypoint.sh
+++ b/apache/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -Eeuo pipefail
+set -Eeo pipefail
 
 # wait for the database to start
 waitfordb() {

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -Eeuo pipefail
+set -Eeo pipefail
 
 # wait for the database to start
 waitfordb() {

--- a/fpm-alpine/entrypoint.sh
+++ b/fpm-alpine/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -Eeuo pipefail
+set -Eeo pipefail
 
 # wait for the database to start
 waitfordb() {

--- a/fpm/entrypoint.sh
+++ b/fpm/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -Eeuo pipefail
+set -Eeo pipefail
 
 # wait for the database to start
 waitfordb() {


### PR DESCRIPTION
'set -u' treat undefined variable as error. Running the image without setting all environment variable fails with it.