### PR TITLE
add DB_USERNAME and DB_PASSWORD env vars to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ services:
     environment:
       - APP_KEY=
       - DB_HOST=db
+      - DB_USERNAME=homestead
+      - DB_PASSWORD=secret
     volumes:
       - data:/var/www/html/storage
     restart: always


### PR DESCRIPTION
Hey there,
first of all a big thank you for this wonderful piece of software :)
Now to my small pull request: I suggest to include the two environment variables in the readme, so that you can easily change the db password and the username, because I always do this and had to search for it and I'm probably not the first: #38 
All the best
tknobi