### PR TITLE
Remove sentry release command

### DIFF
--- a/apache/entrypoint.sh
+++ b/apache/entrypoint.sh
@@ -51,12 +51,6 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
     waitfordb
     ${ARTISAN} monica:update --force -vv
 
-    if [ -n "${SENTRY_SUPPORT:-}" -a "$SENTRY_SUPPORT" = "true" -a -z "${SENTRY_NORELEASE:-}" -a -n "${SENTRY_ENV:-}" ]; then
-        commit=$(cat .sentry-commit)
-        release=$(cat .sentry-release)
-        ${ARTISAN} sentry:release --release="$release" --commit="$commit" --environment="$SENTRY_ENV" --force -v || true
-    fi
-
     if [ ! -f "${STORAGE}/oauth-public.key" -o ! -f "${STORAGE}/oauth-private.key" ]; then
         echo "Passport keys creation ..."
         ${ARTISAN} passport:keys

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -51,12 +51,6 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
     waitfordb
     ${ARTISAN} monica:update --force -vv
 
-    if [ -n "${SENTRY_SUPPORT:-}" -a "$SENTRY_SUPPORT" = "true" -a -z "${SENTRY_NORELEASE:-}" -a -n "${SENTRY_ENV:-}" ]; then
-        commit=$(cat .sentry-commit)
-        release=$(cat .sentry-release)
-        ${ARTISAN} sentry:release --release="$release" --commit="$commit" --environment="$SENTRY_ENV" --force -v || true
-    fi
-
     if [ ! -f "${STORAGE}/oauth-public.key" -o ! -f "${STORAGE}/oauth-private.key" ]; then
         echo "Passport keys creation ..."
         ${ARTISAN} passport:keys

--- a/fpm-alpine/entrypoint.sh
+++ b/fpm-alpine/entrypoint.sh
@@ -51,12 +51,6 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
     waitfordb
     ${ARTISAN} monica:update --force -vv
 
-    if [ -n "${SENTRY_SUPPORT:-}" -a "$SENTRY_SUPPORT" = "true" -a -z "${SENTRY_NORELEASE:-}" -a -n "${SENTRY_ENV:-}" ]; then
-        commit=$(cat .sentry-commit)
-        release=$(cat .sentry-release)
-        ${ARTISAN} sentry:release --release="$release" --commit="$commit" --environment="$SENTRY_ENV" --force -v || true
-    fi
-
     if [ ! -f "${STORAGE}/oauth-public.key" -o ! -f "${STORAGE}/oauth-private.key" ]; then
         echo "Passport keys creation ..."
         ${ARTISAN} passport:keys

--- a/fpm/entrypoint.sh
+++ b/fpm/entrypoint.sh
@@ -51,12 +51,6 @@ if expr "$1" : "apache" 1>/dev/null || [ "$1" = "php-fpm" ]; then
     waitfordb
     ${ARTISAN} monica:update --force -vv
 
-    if [ -n "${SENTRY_SUPPORT:-}" -a "$SENTRY_SUPPORT" = "true" -a -z "${SENTRY_NORELEASE:-}" -a -n "${SENTRY_ENV:-}" ]; then
-        commit=$(cat .sentry-commit)
-        release=$(cat .sentry-release)
-        ${ARTISAN} sentry:release --release="$release" --commit="$commit" --environment="$SENTRY_ENV" --force -v || true
-    fi
-
     if [ ! -f "${STORAGE}/oauth-public.key" -o ! -f "${STORAGE}/oauth-private.key" ]; then
         echo "Passport keys creation ..."
         ${ARTISAN} passport:keys


### PR DESCRIPTION
Remove sentry release command from image

If someone wants to run it, they can run these command when deploying a new image:
```sh
    if [ -n "${SENTRY_SUPPORT:-}" -a "$SENTRY_SUPPORT" = "true" -a -z "${SENTRY_NORELEASE:-}" -a -n "${SENTRY_ENV:-}" ]; then
        commit=$(cat config/.commit)
        release=$(cat config/.release)
        ${ARTISAN} sentry:release --release="$release" --commit="$commit" --environment="$SENTRY_ENV" --force -v || true
    fi
```