### PR TITLE
Bugfix: Changes example MySQL user to match .env

### DIFF
--- a/.examples/raspberrypi/docker-compose.yml
+++ b/.examples/raspberrypi/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: secret
       MYSQL_DATABASE: monica
-      MYSQL_USER: homestead
+      MYSQL_USER: monica
       MYSQL_PASSWORD: secret
     volumes:
       - mysql:/var/lib/mysql


### PR DESCRIPTION
For the raspberry pi example docker-compose file:

In the provided [.env] file the database user is set to "monica" which was different from the user "homestead" set in the [docker-compose.yaml].  This change standardizes on the user "monica".